### PR TITLE
volumeMounts.mountPath should use .Values.vstsWorkspace

### DIFF
--- a/templates/vsts-agent.yaml
+++ b/templates/vsts-agent.yaml
@@ -42,7 +42,7 @@ spec:
             mountPath: /var/run/docker.sock
             readOnly: false
           - name: workspace
-            mountPath: /workspace
+            mountPath: {{ .Values.vstsWorkspace | default "/workspace" }}
         resources:
           limits:
             memory: {{ .Values.resources.limits.mem | quote }}


### PR DESCRIPTION
`volumeMounts.mountPath` should use `.Values.vstsWorkspace`