### PR TITLE
Remove extra . at the end of helm command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The chart can be installed with the following command:
 ```bash
 export VSTS_TOKEN=$(echo -n '<VSTS TOKEN>' | base64)
 
-helm install --namespace <NAMESPACE> --set vstsToken=${VSTS_TOKEN} --set vstsAccount=<VSTS ACCOUNT> --set vstsPool=<VSTS POOL> -f values.yaml vsts-agent .
+helm install --namespace <NAMESPACE> --set vstsToken=${VSTS_TOKEN} --set vstsAccount=<VSTS ACCOUNT> --set vstsPool=<VSTS POOL> -f values.yaml vsts-agent
 ```
 
 Your deployment should look like this if everything works fine:


### PR DESCRIPTION
Helm v2.13.1 returns the following error with the extra . after the chart name

 "Error: This command needs 1 argument: chart name"

see:
https://github.com/Azure/helm-vsts-agent/issues/4#issuecomment-438218779